### PR TITLE
Updated json-c-setup file to remove sudo as its not required

### DIFF
--- a/tools/json-c-setup.sh
+++ b/tools/json-c-setup.sh
@@ -11,5 +11,5 @@ echo "Building json-c library"
 cmake -G Ninja ..
 ninja -j10 -k10
 
-echo " \n\n\n Installing json-c library. Please enter your password: \n\n"
-sudo ninja install
+echo " \n\n\n Installing json-c library. \n\n"
+ninja install


### PR DESCRIPTION
Problem

- During the LLTFI setup process from dockerfile, `docker build` will fail as there is sudo command within the `json-c-setup.sh` which isn't required

Solution 

- Removal of `sudo ninja install` as `ninja install` works fine while running the script 