### PR TITLE
Resolving several issues while installing LLTFI 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,8 +114,13 @@ RUN ./setup -LLFI_BUILD_ROOT $(pwd)/build -LLVM_SRC_ROOT $(pwd)/../llvm-project 
 ### Setting up the env variables
 ENV LLFI_BUILD_ROOT=/home/LLTFI/build
 ENV ONNX_MLIR_BUILD=/home/onnx-mlir/build
-ENV LD_LIBRARY_PATH=/home/LLTFI/tools/json-c/build
 ENV ONNX_MLIR_SRC=/home/onnx-mlir
 ENV LLVM_DST_ROOT=/home/llvm-project/build  
+
+### Setting environment variables for custom include and library paths for json-c library
+ENV C_INCLUDE_PATH=/root/local/include:$C_INCLUDE_PATH
+ENV CPLUS_INCLUDE_PATH=/root/local/include:$CPLUS_INCLUDE_PATH
+ENV LIBRARY_PATH=/root/local/lib:$LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/root/local/lib:$LD_LIBRARY_PATH
 
 WORKDIR /home/LLTFI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,7 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 
 RUN apt-get update
 RUN apt-get install unzip
+RUN apt-get install -y wget
 
 ### libprotoc
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.17.2/protobuf-all-3.17.2.zip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,9 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
     mkdir llvm-project/build && cd llvm-project/build && \
     cmake -G Ninja ../llvm \
       -DLLVM_ENABLE_PROJECTS="clang;mlir" \
-      -DLLVM_BUILD_TESTS=ON \
       -DLLVM_TARGETS_TO_BUILD="host" \
       -DLLVM_ENABLE_ASSERTIONS=ON \
+      -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_RTTI=ON && \
     cmake --build . --target clang check-mlir mlir-translate opt llc lli llvm-dis llvm-link -j${NPROC} && \
     ninja install -j${NPROC} && \
@@ -114,3 +114,5 @@ RUN ./setup -LLFI_BUILD_ROOT $(pwd)/build -LLVM_SRC_ROOT $(pwd)/../llvm-project 
 ENV LLFI_BUILD_ROOT=/home/LLTFI/build
 ENV ONNX_MLIR_BUILD=/home/onnx-mlir/build
 ENV LD_LIBRARY_PATH=/home/LLTFI/tools/json-c/build
+
+WORKDIR /home/LLTFI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,6 @@ RUN pip install tf2onnx
 RUN pip3 install pyyaml===5.4.1
    
 WORKDIR /home/
-RUN mkdir LLTFI
 
 ### LLVM
 RUN git clone https://github.com/llvm/llvm-project.git && \
@@ -84,10 +83,9 @@ RUN make check -j${NPROC}
 RUN make install
 RUN ldconfig
 
-WORKDIR /home/LLTFI/
+WORKDIR /home/
 RUN git clone https://github.com/DependableSystemsLab/LLTFI.git
 
-WORKDIR /home/
 
 ### ONNX_MLIR
 RUN git clone --recursive https://github.com/DependableSystemsLab/onnx-mlir-lltfi.git && \
@@ -104,10 +102,15 @@ RUN git clone --recursive https://github.com/DependableSystemsLab/onnx-mlir-lltf
     cmake --build . -j${NPROC} && \
     ninja install
 
-WORKDIR /home/LLTFI/LLTFI
+WORKDIR /home/LLTFI
 
 ### LLTFI
-RUN ./setup -LLFI_BUILD_ROOT $(pwd)/build -LLVM_SRC_ROOT $(pwd)/../../llvm-project -LLVM_DST_ROOT $(pwd)/../../llvm-project/build && \
+RUN ./setup -LLFI_BUILD_ROOT $(pwd)/build -LLVM_SRC_ROOT $(pwd)/../llvm-project -LLVM_DST_ROOT $(pwd)/../llvm-project/build && \
     export LLFI_BUILD_ROOT=$(pwd)/build && \
-    cd /home/LLTFI/LLTFI/tools && \
+    cd /home/LLTFI/tools && \
     sh json-c-setup.sh
+
+### Setting up the env variables
+ENV LLFI_BUILD_ROOT=/home/LLTFI/build
+ENV ONNX_MLIR_BUILD=/home/onnx-mlir/build
+ENV LD_LIBRARY_PATH=/home/LLTFI/tools/json-c/build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,5 +114,7 @@ RUN ./setup -LLFI_BUILD_ROOT $(pwd)/build -LLVM_SRC_ROOT $(pwd)/../llvm-project 
 ENV LLFI_BUILD_ROOT=/home/LLTFI/build
 ENV ONNX_MLIR_BUILD=/home/onnx-mlir/build
 ENV LD_LIBRARY_PATH=/home/LLTFI/tools/json-c/build
+ENV ONNX_MLIR_SRC=/home/onnx-mlir
+ENV LLVM_DST_ROOT=/home/llvm-project/build  
 
 WORKDIR /home/LLTFI

--- a/tools/json-c-setup.sh
+++ b/tools/json-c-setup.sh
@@ -8,7 +8,7 @@ mkdir build
 cd build
 
 echo "Building json-c library"
-cmake -G Ninja ..
+cmake -G Ninja .. -DCMAKE_INSTALL_PREFIX=~/local
 ninja -j10 -k10
 
 echo " \n\n\n Installing json-c library. \n\n"


### PR DESCRIPTION
***Problems***

1) For LLTFI, there is an extra folder which only contains the `LLTFI repo`, therefore removal is required for the extra LLTFI folder
2) Replacement of path folder for `LLTFI build` is needed due to 1) 
3) Build for LLVM is needed in `release mode` to reduce memory space taken by the docker image 
4) After docker build, there were no env variables configured which causes extra steps for developer to do in order to run LLTFI
5) Installing of json-c library needs sudo power in regular Linux desktop and does not need sudo power while running in docker, therefore need to have a new path for json-c where both of the cases above doesn't need sudo power 
6) `wget` command isn't installed after the `docker build` has been done 

***Solutions***

1) Extra folder for LLTFI is removed and now the new path is `/home/LLTFI`
2) New path for LLTFI build is `/home/LLTFI/build`
3) LLVM build is now done in release mode 
4) In dockerfile, the script ensures to set the env variables as well to have a smooth experience for developers to run LLTFI 
5) Pathway to install json-c library is now set to be `~/local` since the path is in the user's home directory, the script would not require sudo power for both manual installation and dockerfile build
6) Installation of `wget` is added within the `Dockerfile`
