### PR TITLE
Updating links for onnx models for ML programs

### DIFF
--- a/sample_programs/ml_sample_programs/nlp_models/bert/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/bert/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "\n$FILE exists. Skip downloading."
 else
     echo "\n$FILE does not exist. Downloading the model..."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/bert-squad/model/bertsquad-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/bert-squad/model/bertsquad-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/gpt2-lm-head-10/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/gpt2-lm-head-10/compile.sh
@@ -7,7 +7,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/gpt2/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/gpt2/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/gpt-2/model/gpt2-10.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/gpt-2/model/gpt2-10.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/roberta-base-11/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/roberta-base-11/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/roberta/model/roberta-base-11.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/roberta/model/roberta-base-11.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/roberta-seq-classification-9/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/roberta-seq-classification-9/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/roberta/model/roberta-sequence-classification-9.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/roberta/model/roberta-sequence-classification-9.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/t5-decoder/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/t5-decoder/compile.sh
@@ -5,7 +5,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/t5/model/t5-encoder-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/t5/model/t5-encoder-12.onnx
 fi
 
 DEC_FILE=t5-decoder-with-lm-head-12.onnx
@@ -13,7 +13,7 @@ if [ -f "$DEC_FILE" ]; then
     echo "$DEC_FILE exists."
 else
     echo "$DEC_FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/t5/model/t5-decoder-with-lm-head-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/t5/model/t5-decoder-with-lm-head-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/nlp_models/t5-encoder/compile.sh
+++ b/sample_programs/ml_sample_programs/nlp_models/t5-encoder/compile.sh
@@ -5,7 +5,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/t5/model/t5-encoder-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/t5/model/t5-encoder-12.onnx
 fi
 
 DEC_FILE=t5-decoder-with-lm-head-12.onnx
@@ -13,7 +13,7 @@ if [ -f "$DEC_FILE" ]; then
     echo "$DEC_FILE exists."
 else
     echo "$DEC_FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/text/machine_comprehension/t5/model/t5-decoder-with-lm-head-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/text/machine_comprehension/t5/model/t5-decoder-with-lm-head-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/bvlcalexnet-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/bvlcalexnet-12/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/alexnet/model/bvlcalexnet-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/alexnet/model/bvlcalexnet-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/googlenet-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/googlenet-12/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/inception_and_googlenet/googlenet/model/googlenet-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-12.onnx
 fi
 
 

--- a/sample_programs/ml_sample_programs/vision_models/inception-v1-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/inception-v1-12/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/resnet50-v1-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/resnet50-v1-12/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-v1-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/resnet/model/resnet50-v1-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/shufflenetv2_10/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/shufflenetv2_10/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/shufflenet/model/shufflenet-v2-10.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/shufflenet/model/shufflenet-v2-10.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/squeezenet1.0-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/squeezenet1.0-12/compile.sh
@@ -5,7 +5,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.0-12.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/squeezenet/model/squeezenet1.0-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/vgg16-12/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/vgg16-12/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/classification/vgg/model/vgg16-12.onnx 
+    wget https://github.com/onnx/models/raw/main/validated/vision/classification/vgg/model/vgg16-12.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"

--- a/sample_programs/ml_sample_programs/vision_models/yolo3/compile.sh
+++ b/sample_programs/ml_sample_programs/vision_models/yolo3/compile.sh
@@ -4,7 +4,7 @@ if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else
     echo "$FILE does not exist."
-    wget https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/yolov3/model/yolov3-10.onnx
+    wget https://github.com/onnx/models/raw/main/validated/vision/object_detection_segmentation/yolov3/model/yolov3-10.onnx
 fi
 
 printf "\n[Compile Script]: Convert TF model to LLVM IR\n"


### PR DESCRIPTION
***Problems***

- After the onnx model repo update, all links were replaced which caused errors within the LLTFI model as resources were no longer available at the old link 

***Solutions***

- After looking at the updated onnx repo, links for onnx models has been updated so that LLTFI could download the resources and do fault injection accordingly 